### PR TITLE
Add configurable tool belt rendering

### DIFF
--- a/src/main/java/com/daniking/backtools/BackToolFeatureRenderer.java
+++ b/src/main/java/com/daniking/backtools/BackToolFeatureRenderer.java
@@ -18,7 +18,6 @@ import net.minecraft.entity.EntityPose;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ShieldItem;
-import net.minecraft.item.SwordItem;
 import net.minecraft.util.Arm;
 import net.minecraft.util.math.RotationAxis;
 

--- a/src/main/java/com/daniking/backtools/BackToolFeatureRenderer.java
+++ b/src/main/java/com/daniking/backtools/BackToolFeatureRenderer.java
@@ -18,6 +18,7 @@ import net.minecraft.entity.EntityPose;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ShieldItem;
+import net.minecraft.item.SwordItem;
 import net.minecraft.util.Arm;
 import net.minecraft.util.math.RotationAxis;
 
@@ -77,11 +78,24 @@ public class BackToolFeatureRenderer <T extends AbstractClientPlayerEntity, M ex
                 final int i = ConfigHandler.getToolOrientation(this.mainStack.getItem());
                 matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(i));
             }
+            if (ConfigHandler.isBeltTool(this.mainStack.getItem()) /*this.mainStack.getItem() instanceof SwordItem*/) {
+                float swordScale = 0.8F;
+                matrices.scale(swordScale, swordScale, swordScale);
+
+                if (this.mainArm == Arm.LEFT) {
+                    matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(90F));
+                    matrices.translate(0.19F, 0.6F, -0.33F);
+                } else {
+                    matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(270F));
+                    matrices.translate(0.19F, 0.6F, 0.33F);
+                }
+            }
             if (ticks > 0) {
                 matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees((ticks + partialTicks) * 40F));
             }
             MinecraftClient.getInstance().getItemRenderer().renderItem(this.mainStack, ModelTransformationMode.FIXED, light, OverlayTexture.DEFAULT_UV, matrices, provider, null, 0);
         }
+
         if (!this.offStack.isEmpty()) {
             if (this.mainArm == Arm.LEFT) {
                 matrices.scale(-1F, 1F, -1F);

--- a/src/main/java/com/daniking/backtools/BackToolsConfig.java
+++ b/src/main/java/com/daniking/backtools/BackToolsConfig.java
@@ -9,8 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static java.lang.Boolean.TRUE;
-
 @Environment(EnvType.CLIENT)
 @Config(name = "BackTools")
 public class BackToolsConfig implements ConfigData {

--- a/src/main/java/com/daniking/backtools/BackToolsConfig.java
+++ b/src/main/java/com/daniking/backtools/BackToolsConfig.java
@@ -9,11 +9,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.lang.Boolean.TRUE;
+
 @Environment(EnvType.CLIENT)
 @Config(name = "BackTools")
 public class BackToolsConfig implements ConfigData {
     @Comment(value = "\nThese options affect only the client that loads the mod.\nIt is not possible to override the environment of the mod.")
     public final String environment = EnvType.CLIENT.name();
+    @Comment(value = "Whether belt swords should be enabled.")
+    public List<String> beltTools = new ArrayList<>();
     @Comment(value = "Enabled tools, by their resource name. Eg: minecraft:diamond_hoe. Putting any entry in here converts BackTools to a whitelist-only mod. Disabled Tools will be ignored.")
     public List<String> enabledTools = new ArrayList<>();
     @Comment(value = "Disabled tools, by their resource name. Eg: minecraft:diamond_hoe")

--- a/src/main/java/com/daniking/backtools/ConfigHandler.java
+++ b/src/main/java/com/daniking/backtools/ConfigHandler.java
@@ -10,8 +10,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
-import static java.lang.Boolean.TRUE;
-
 @Environment(EnvType.CLIENT)
 public class ConfigHandler {
 

--- a/src/main/java/com/daniking/backtools/ConfigHandler.java
+++ b/src/main/java/com/daniking/backtools/ConfigHandler.java
@@ -10,13 +10,15 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
+import static java.lang.Boolean.TRUE;
+
 @Environment(EnvType.CLIENT)
 public class ConfigHandler {
 
     public static final HashMap<Class<?>, Integer> TOOL_ORIENTATIONS = new HashMap<>();
     public static final HashSet<Identifier> ENABLED_TOOLS = new HashSet<>();
     public static final Set<Identifier> DISABLED_TOOLS = new HashSet<>();
-
+    public static final HashSet<Identifier> BELT_TOOLS = new HashSet<>();
     public static int getToolOrientation(Item item) {
         return getToolOrientation(item.getClass());
     }
@@ -43,6 +45,16 @@ public class ConfigHandler {
         }
         //else allow default items
         return item instanceof MiningToolItem || item instanceof SwordItem || item instanceof ShieldItem || item instanceof TridentItem || item instanceof BowItem || item instanceof ShearsItem || item instanceof CrossbowItem || item instanceof FishingRodItem;
+    }
+
+    public static  boolean isBeltTool(final Item item) {
+        final Identifier registeryName = new Identifier(Registries.ITEM.getId(item).getNamespace(), item.toString());
+        ClientSetup.config.beltTools.forEach(beltTool -> BELT_TOOLS.add(new Identifier(beltTool)));
+        
+        if (BELT_TOOLS.contains(registeryName)) {
+            return true;
+        }
+        return false;
     }
 
     public static void init() {


### PR DESCRIPTION
This pull request adds configurable tool belt item rendering.
![belt](https://github.com/DanikingRD/BackTools/assets/118913639/18f2a783-b806-4506-981c-52efc76bcf4d)
This is configured using a list like the one you had set up for what items could render, and is empty by default. I am very new to Java, so if there's any changes needed let me know. Also if you don't want this because of scope creep that's OK with me.