### PR TITLE
Tags

### DIFF
--- a/src/main/java/com/daniking/backtools/BackToolFeatureRenderer.java
+++ b/src/main/java/com/daniking/backtools/BackToolFeatureRenderer.java
@@ -42,7 +42,8 @@ public class BackToolFeatureRenderer <M extends PlayerEntityModel> extends Playe
             matrixStack.push();
             this.getContextModel().body.rotate(matrixStack);
             boolean isHelicopterMode = ConfigHandler.isHelicopterModeOn() && (playerRenderState.isSwimming || playerRenderState.isGliding);
-            this.renderItem(!playerRenderState.equippedChestStack.isEmpty() ? 1.0F : playerRenderState.jacketVisible ? 0.5F : 0F, matrixStack, vertexConsumerProvider, light, isHelicopterMode ? playerRenderState.age : 0);
+            this.renderItem(!playerRenderState.equippedChestStack.isEmpty() ? 1.0F : playerRenderState.jacketVisible ? 0.5F : 0F,
+                matrixStack, vertexConsumerProvider, light, isHelicopterMode ? playerRenderState.age : 0);
             matrixStack.pop();
         }
     }
@@ -55,8 +56,8 @@ public class BackToolFeatureRenderer <M extends PlayerEntityModel> extends Playe
             if (this.mainArm == Arm.RIGHT) {
                 matrices.scale(-1F, 1F, -1F);
             }
-            boolean bl = this.mainStack.getItem() instanceof ShieldItem;
-            if (bl) {
+
+            if (this.mainStack.getItem() instanceof ShieldItem) {
                 float scale = 1.5F;
                 matrices.scale(scale, scale, scale);
                 if (this.mainArm == Arm.LEFT) {
@@ -67,11 +68,11 @@ public class BackToolFeatureRenderer <M extends PlayerEntityModel> extends Playe
                     matrices.translate(-1F / 16F, 0.25F / 16F, 1.0F / 16F);
                     matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(25F));
                 }
-            }
-            if (!bl) {
+            } else {
                 final float i = ConfigHandler.getToolOrientation(this.mainStack.getItem());
                 matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(i));
             }
+
             if (ConfigHandler.isBeltTool(this.mainStack.getItem())) {
                 float swordScale = 0.8F;
                 matrices.scale(swordScale, swordScale, swordScale);
@@ -84,6 +85,7 @@ public class BackToolFeatureRenderer <M extends PlayerEntityModel> extends Playe
                     matrices.translate(0.19F, 0.6F, 0.33F);
                 }
             }
+
             if (age > 0) {
                 matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(age * 40F));
             }

--- a/src/main/java/com/daniking/backtools/BackToolsConfig.java
+++ b/src/main/java/com/daniking/backtools/BackToolsConfig.java
@@ -15,20 +15,29 @@ import java.util.List;
 public class BackToolsConfig implements ConfigData {
     @Comment(value = "\nThese options affect only the client that loads the mod.\nIt is not possible to override the environment of the mod.")
     public final String environment = EnvType.CLIENT.name();
-    @Comment(value = "What items should render on your belt.")
+    @Comment(value = "What items should render on your belt by their resource name. Eg: minecraft:diamond_hoe")
     public List<String> beltTools = new ArrayList<>();
     @Comment(value = "Enabled tools, by their resource name. Eg: minecraft:diamond_hoe. Putting any entry in here converts BackTools to a whitelist-only mod. Disabled Tools will be ignored.")
     public List<String> enabledTools = new ArrayList<>();
     @Comment(value = "Disabled tools, by their resource name. Eg: minecraft:diamond_hoe")
     public List<String> disabledTools = new ArrayList<>();
-    @Comment(value = "Tool orientation, by class file and degrees. Separate with \":\" . See defaults for examples.")
+    @Comment(value =
+        """
+        Tool orientation, by class file and degrees.
+        Entries starting with "#" are tags (https://minecraft.wiki/w/Tag)
+        Leading namespace (e.g. minecraft:) is optional.
+        Separate with ":" for rotation.
+        Later occurrences of the same item override the previous once (Like in hoes override their config values set in mining).
+        Item types not listed here will default to 0.
+        "See defaults for examples.""")
     public List<String> toolOrientation = Arrays.asList(
-        "net.minecraft.item.MiningToolItem" + ":0",
-        "net.minecraft.item.HoeItem" + ":0",
-        "net.minecraft.item.FishingRodItem" + ":0",
-        "net.minecraft.item.TridentItem" + ":0",
-        "net.minecraft.item.MaceItem" + ":-22.5",
-        "net.minecraft.item.RangedWeaponItem" + ":90");
+        "#minecraft:enchantable/mining" + ":0",
+        "#minecraft:hoes" + ":0",
+        "#minecraft:enchantable/fishing" + ":0",
+        "#minecraft:enchantable/trident" + ":0",
+        "mace" + ":-22.5",
+        "bow" + ":90",
+        "crossbow" + ":90");
     @Comment(value = "Get in swimming position and your tools go \"Weeee\"")
     public boolean helicopterMode = false;
     @Comment(value = "If true, tools render with capes")

--- a/src/main/java/com/daniking/backtools/ClientSetup.java
+++ b/src/main/java/com/daniking/backtools/ClientSetup.java
@@ -5,6 +5,7 @@ import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.lifecycle.v1.CommonLifecycleEvents;
 
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -18,6 +19,8 @@ public class ClientSetup implements ClientModInitializer {
     public void onInitializeClient() {
         AutoConfig.register(BackToolsConfig.class, JanksonConfigSerializer::new);
         config = AutoConfig.getConfigHolder(BackToolsConfig.class).getConfig();
-        ConfigHandler.init();
+
+        // since we depend on item tags, our config can't load until the tags are loaded first. (creating / joining worlds)
+        CommonLifecycleEvents.TAGS_LOADED.register((registries, client) -> ConfigHandler.init());
     }
 }

--- a/src/main/java/com/daniking/backtools/ConfigHandler.java
+++ b/src/main/java/com/daniking/backtools/ConfigHandler.java
@@ -19,11 +19,11 @@ import java.util.regex.Pattern;
 
 @Environment(EnvType.CLIENT)
 public class ConfigHandler {
-    private static final HashSet<Identifier> BELT_TOOLS = new HashSet<>();
     private static final @NotNull Pattern TOOL_ORIENTATION_PATTERN = Pattern.compile("^(?<isTag>#)?(?:(?<namespace>minecraft):)?(?<itemOrTag>.+?):(?<orientation>.+?)$");
     private static final Map<Item, Float> TOOL_ORIENTATIONS = new LinkedHashMap<>();
     private static final Set<Identifier> ENABLED_TOOLS = new HashSet<>();
     private static final Set<Identifier> DISABLED_TOOLS = new HashSet<>();
+    private static final HashSet<Identifier> BELT_TOOLS = new HashSet<>();
     private static boolean HELICOPTER_MODE = false;
     private static boolean RENDER_WITH_CAPES = true;
 

--- a/src/main/java/com/daniking/backtools/HeldItemContext.java
+++ b/src/main/java/com/daniking/backtools/HeldItemContext.java
@@ -11,9 +11,7 @@ public class HeldItemContext {
     public ItemStack activeMain = ItemStack.EMPTY;
     public ItemStack activeOff = ItemStack.EMPTY;
 
-
     public void tick(ItemStack main, ItemStack off) {
-
         if (droppedEntity != null && !droppedEntity.getStack().isEmpty()) {
             this.reset(droppedEntity.getStack());
             droppedEntity = null;
@@ -21,15 +19,15 @@ public class HeldItemContext {
         }
 
         //check to see if we should remove the main hand back tool
-        if(areStacksEqual(main, previousMain) || areStacksEqual(off, previousMain)) {
+        if(ItemStack.areItemsAndComponentsEqual(main, previousMain) || ItemStack.areItemsAndComponentsEqual(off, previousMain)) {
             previousMain = ItemStack.EMPTY;
         }
 
-        if(areStacksEqual(main, previousOff) || areStacksEqual(off, previousOff)) {
+        if(ItemStack.areItemsAndComponentsEqual(main, previousOff) || ItemStack.areItemsAndComponentsEqual(off, previousOff)) {
             previousOff = ItemStack.EMPTY;
         }
         //set back tool if main tool was an item, and we don't see that item anymore.
-        if(!activeMain.isEmpty() && !areStacksEqual(main, activeMain) && !areStacksEqual(off, activeMain)) {
+        if(!activeMain.isEmpty() && !ItemStack.areItemsAndComponentsEqual(main, activeMain) && !ItemStack.areItemsAndComponentsEqual(off, activeMain)) {
             previousMain = activeMain;
             activeMain = ItemStack.EMPTY;
         }
@@ -37,45 +35,38 @@ public class HeldItemContext {
 //        //set back tool if offhand tool was an item, and we don't see that item anymore.
 //        this.updatePreviousStacks(main, off);
 
-        if(!activeOff.isEmpty() && !areStacksEqual(main, activeOff) && !areStacksEqual(off, activeOff)) {
+        if(!activeOff.isEmpty() && !ItemStack.areItemsAndComponentsEqual(main, activeOff) && !ItemStack.areItemsAndComponentsEqual(off, activeOff)) {
             previousOff = activeOff;
             activeOff = ItemStack.EMPTY;
         }
         if(ConfigHandler.isItemEnabled(main.getItem())) {
             activeMain = main;
-            if(areStacksEqual(activeMain, activeOff)) {
+            if(ItemStack.areItemsAndComponentsEqual(activeMain, activeOff)) {
                 activeOff = ItemStack.EMPTY;
             }
         }
 
         if(ConfigHandler.isItemEnabled(off.getItem())) {
             activeOff = off;
-            if(areStacksEqual(activeOff, activeMain)) {
+            if(ItemStack.areItemsAndComponentsEqual(activeOff, activeMain)) {
                 activeMain = ItemStack.EMPTY;
             }
         }
     }
 
     private void reset(ItemStack entityStack) {
-        if (areStacksEqual(entityStack, previousMain)) {
+        if (ItemStack.areItemsAndComponentsEqual(entityStack, previousMain)) {
             previousMain = ItemStack.EMPTY;
         }
-        if (areStacksEqual(entityStack, activeMain)) {
+        if (ItemStack.areItemsAndComponentsEqual(entityStack, activeMain)) {
             activeMain = ItemStack.EMPTY;
         }
         //Check to see if we should remove the offhand BackTool
-        if (areStacksEqual(entityStack, previousOff)) {
+        if (ItemStack.areItemsAndComponentsEqual(entityStack, previousOff)) {
             previousOff = ItemStack.EMPTY;
         }
-        if (areStacksEqual(entityStack, activeOff)) {
+        if (ItemStack.areItemsAndComponentsEqual(entityStack, activeOff)) {
             activeOff = ItemStack.EMPTY;
         }
-    }
-
-    public static boolean areStacksEqual(final ItemStack a, final ItemStack b) {
-        return !a.isEmpty() && !b.isEmpty() &&
-            (a.getComponents().isEmpty() || !b.getComponents().isEmpty()) &&
-            (!a.getComponents().isEmpty() || b.getComponents().isEmpty()) &&
-            a.getItem() == b.getItem();
     }
 }


### PR DESCRIPTION
closes #27

This switches from a class based system to group items together to a [#tag](https://minecraft.wiki/w/Tag#Item_tags) system.
Two additional things come into play here: 
1. ~~In order to fully replace the previous behavior, this depends on an update to at least 1.20.5, because of the newly added tags there.~~
2. Tags are not loaded until a player joins a world (inclusive any server) or does some niche things like opening the create new world screen or optimizing an existing one.
Since the mod ever comes into action once the player has successfully loaded in the game and doesn't have an ingame config this should be fine. But one should mind that in the [menu screen](https://minecraft.fandom.com/wiki/Menu_screen) the mod might not have loaded any config or maybe has obsolete values.
Also using the vanilla /reload command also might alter the behavior of the mod. This is of course intentional, but should still be kept in mind.